### PR TITLE
fix: rename catalog-info spec properties

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,8 +7,8 @@ spec:
   lifecycle: unknown
   owner: pms
   coder:
-    template: "devcontainers"
-    createMode: "auto"
+    templateName: "devcontainers"
+    mode: "auto"
     params:
       repo: "custom"
       custom_repo: "https://github.com/bcdr-demos/python-project"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,6 +11,6 @@ spec:
     createMode: "auto"
     params:
       repo: "custom"
-      repo_url: "https://github.com/bcdr-demos/python-project"
+      custom_repo: "https://github.com/bcdr-demos/python-project"
       region: "us-pittsburgh"
 


### PR DESCRIPTION
Minor fix to the config file to make sure it matches what we're using in Coder proper